### PR TITLE
Fix InitActions never being called

### DIFF
--- a/scripting/l4d2_sb_ai_improver.sp
+++ b/scripting/l4d2_sb_ai_improver.sp
@@ -19,7 +19,7 @@ public Plugin myinfo =
 	name 		= "[L4D2] Survivor Bot AI Improver",
 	author 		= "Emana202, Kerouha",
 	description = "Attempt at improving survivor bots' AI and behaviour as much as possible.",
-	version 	= "1.5.1k",
+	version 	= "1.5.2k",
 	url 		= "https://forums.alliedmods.net/showthread.php?t=342872"
 }
 
@@ -4787,11 +4787,11 @@ public void OnMapStart()
 	for (int i = 1; i <= MaxClients; i++)g_fClient_ThinkFunctionDelay[i] = GetGameTime() + (g_bLateLoad ? 1.0 : 10.0);
 	CreateEntityArrayLists();
 	
-	//if (g_bExtensionActions && !g_bInitActionIDs)
-	//{
+	if (g_bExtensionActions && !g_bInitActionIDs)
+	{
 	//	PrintToServer("OnMapStart: InitActionIDs");
-	//	InitActionIDs();
-	//}
+		InitActionIDs();
+	}
 	RequestFrame(CreateVScriptFunctions);
 	InitMeleeIDs();
 


### PR DESCRIPTION
Fix InitActions function never being called in OnMapStart, causing all Actions actions to break in OnActionCreated because all g_ActionID[] values were always zero.  Increment version to 1.5.2k.